### PR TITLE
OpenAI Model's docs required model_name key missing

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -94,10 +94,11 @@ Create a file in that directory called `extra-openai-models.yaml`.
 Let's say OpenAI have just released the `gpt-3.5-turbo-0613` model and you want to use it, despite LLM not yet shipping support. You could configure that by adding this to the file:
 
 ```yaml
-- model_id: gpt-3.5-turbo-0613
-  aliases: ["0613"]
+- model_id: gpt-4-turbo-2024-04-09
+  model_name: gpt-4-turbo-2024-04-09
+  aliases: ["g4t"]
 ```
-The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model.
+The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model. You must also include the `model_name`.
 
 If the model is a completion model (such as `gpt-3.5-turbo-instruct`) add `completion: true` to the configuration.
 


### PR DESCRIPTION
Without `model_name` llm crashes. Today OpenAI released gpt-4-turbo-2024-04-09 and gpt-4-turbo is pointing to it but without adding a custom model to the config it's not possible to use it.

From [OpenAI's Models Docs](https://platform.openai.com/docs/models/continuous-model-upgrades)
- gpt-4-turbo (new)
  New GPT-4 Turbo with Vision
  The latest GPT-4 Turbo model with vision capabilities. Vision requests can now use JSON mode and function calling. 
  Currently points to gpt-4-turbo-2024-04-09.
  128,000 tokens. Up to Dec 2023

- gpt-4-turbo-2024-04-09 (new)
  GPT-4 Turbo with Vision model.
  Vision requests can now use JSON mode and function calling. 
  **gpt-4-turbo** currently points to this version.
  128,000 tokens. Up to Dec 2023


Crash log:

```
❯ OPENAI_LOG=debug LLM_OPENAI_SHOW_RESPONSES=true llm models
Traceback (most recent call last):
  File "/Users/gastonmorixe/.local/bin/llm", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/llm/cli.py", line 799, in models_list
    for model_with_aliases in get_models_with_aliases():
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/llm/__init__.py", line 80, in get_models_with_aliases
    pm.hook.register_models(register=register)
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/pluggy/_callers.py", line 113, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gastonmorixe/.local/pipx/venvs/llm/lib/python3.12/site-packages/llm/default_plugins/openai_models.py", line 49, in register_models
    model_name = extra_model["model_name"]
                 ~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'model_name'
```